### PR TITLE
Fix deprecation warning in messages

### DIFF
--- a/nameko/messaging.py
+++ b/nameko/messaging.py
@@ -35,7 +35,7 @@ def encode_to_headers(context_data, prefix=HEADER_PREFIX):
 
 def decode_from_headers(headers, prefix=HEADER_PREFIX):
     return {
-        re.sub("^{}\.".format(prefix), "", key): value
+        re.sub(r"^{}\.".format(prefix), "", key): value
         for key, value in headers.items()
     }
 


### PR DESCRIPTION
Try to fix deprecation warning:
```
/usr/local/lib/python3.6/site-packages/nameko/messaging.py:38: DeprecationWarning: invalid escape sequence \.
     re.sub("^{}\.".format(prefix), "", key): value
```